### PR TITLE
Add "--enable-media-stream" command-line flag used to validate local …

### DIFF
--- a/gstcefsrc.cc
+++ b/gstcefsrc.cc
@@ -218,6 +218,7 @@ class App : public CefApp
                                              CefRefPtr<CefCommandLine> command_line) override
   {
     command_line->AppendSwitchWithValue("autoplay-policy", "no-user-gesture-required");
+    command_line->AppendSwitch("enable-media-stream");
     command_line->AppendSwitch("disable-gpu");
     command_line->AppendSwitch("disable-dev-shm-usage"); /* https://github.com/GoogleChrome/puppeteer/issues/1834 */
     command_line->AppendSwitch("disable-gpu-compositing");


### PR DESCRIPTION
…ressources such as a webcam.

This is quite usefull with webrtc app for instance such as http://apprtc.appspot.com/.