### PR TITLE
Use F32LE format for audio

### DIFF
--- a/gstcefdemux.cc
+++ b/gstcefdemux.cc
@@ -4,7 +4,7 @@
 #include "gstcefaudiometa.h"
 
 #define CEF_VIDEO_CAPS "video/x-raw, format=BGRA, width=[1, 2147483647], height=[1, 2147483647], framerate=[1/1, 60/1]"
-#define CEF_AUDIO_CAPS "audio/x-raw, format=F32BE, rate=[1, 2147483647], channels=[1, 2147483647], layout=interleaved"
+#define CEF_AUDIO_CAPS "audio/x-raw, format=F32LE, rate=[1, 2147483647], channels=[1, 2147483647], layout=interleaved"
 
 G_DEFINE_TYPE (GstCefDemux, gst_cef_demux, GST_TYPE_ELEMENT);
 
@@ -53,7 +53,7 @@ gst_cef_demux_push_events (GstCefDemux *demux)
     /* Push some dummy caps so that our initial gap events don't
      * get refused */
     audio_caps = gst_caps_new_simple ("audio/x-raw",
-        "format", G_TYPE_STRING, "F32BE",
+        "format", G_TYPE_STRING, "F32LE",
         "rate", G_TYPE_INT, 44100,
         "channels", G_TYPE_INT, 2,
         "layout", G_TYPE_STRING, "interleaved",

--- a/gstcefsrc.cc
+++ b/gstcefsrc.cc
@@ -38,7 +38,7 @@ enum
 G_DEFINE_TYPE (GstCefSrc, gst_cef_src, GST_TYPE_PUSH_SRC);
 
 #define CEF_VIDEO_CAPS "video/x-raw, format=BGRA, width=[1, 2147483647], height=[1, 2147483647], framerate=[1/1, 60/1]"
-#define CEF_AUDIO_CAPS "audio/x-raw, format=F32BE, rate=[1, 2147483647], channels=[1, 2147483647], layout=interleaved"
+#define CEF_AUDIO_CAPS "audio/x-raw, format=F32LE, rate=[1, 2147483647], channels=[1, 2147483647], layout=interleaved"
 
 static GstStaticPadTemplate gst_cef_src_template =
 GST_STATIC_PAD_TEMPLATE ("src",


### PR DESCRIPTION
From what I know big-endian is rare format. When I was writing custom recorder for cef my output was in F32LE