### PR TITLE
Add a gpu support property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 third_party/
 build/
+.vscode/

--- a/gstcefsrc.h
+++ b/gstcefsrc.h
@@ -37,6 +37,7 @@ struct _GstCefSrc {
   guint64 n_frames;
   gulong cef_work_id;
   gchar *url;
+  gboolean gpu;
   CefRefPtr<CefBrowser> browser;
   CefRefPtr<CefApp> app;
 


### PR DESCRIPTION
With GPU 60 fps
![image](https://user-images.githubusercontent.com/35471680/110040423-768e7980-7d4b-11eb-83d2-4228f1ff4160.png)

Without GPU only 6-7 fps

I'm still very surprised that this works. Was under impression that GPU in osr mode works only under windows

Tested with this site https://threejs.org/examples/#webgl_points_dynamic

p.s. first c code I write in years