### PR TITLE
cefaudiometa: Remove incorrect use of volatile

### DIFF
--- a/gstcefaudiometa.cc
+++ b/gstcefaudiometa.cc
@@ -37,7 +37,7 @@ gst_buffer_add_cef_audio_meta (GstBuffer * buffer, GstBufferList *buffers)
 GType
 gst_cef_audio_meta_api_get_type (void)
 {
-  static volatile GType type;
+  static GType type;
   static const gchar *tags[] = { NULL };
 
   if (g_once_init_enter (&type)) {


### PR DESCRIPTION
Newer GCC complains with:
```
error: argument 2 of ‘__atomic_load’ must not be a pointer to a ‘volatile’ type
```