### PR TITLE
implement make install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,11 @@ project(gstcef)
 
 set_property(GLOBAL PROPERTY OS_FOLDERS ON)
 
+if(POLICY CMP0074)
+    #policy for <PackageName>_ROOT variables
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 set(CEF_VERSION "88.2.9+g5c8711a+chromium-88.0.4324.182")
 set(CEF_ESCAPED_VERSION "88.2.9%2Bg5c8711a%2Bchromium-88.0.4324.182")
 
@@ -73,8 +78,24 @@ SET_LIBRARY_TARGET_PROPERTIES("gstcef")
 add_dependencies("gstcef" libcef_dll_wrapper)
 target_link_libraries("gstcef" libcef_lib libcef_dll_wrapper ${CEF_STANDARD_LIBS} ${GST_LIBRARIES})
 target_include_directories("gstcef" PUBLIC ${GST_INCLUDE_DIRS})
-target_compile_definitions("gstcef" PUBLIC "-DCEF_SUBPROCESS_PATH=\"$<TARGET_FILE:gstcefsubprocess>\"")
-target_compile_definitions("gstcef" PUBLIC "-DCEF_LOCALES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/locales\"")
+
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CEF_SUBPROCESS_BASE_PATH "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}")
+else()
+  set(CEF_SUBPROCESS_BASE_PATH "${CMAKE_INSTALL_PREFIX}")
+endif()
+
+message(STATUS "USING ${CEF_SUBPROCESS_BASE_PATH} AS BUILD PATH")
+
+target_compile_definitions(
+  "gstcef" PUBLIC
+  "-DCEF_SUBPROCESS_PATH=\"${CEF_SUBPROCESS_BASE_PATH}/gstcefsubprocess\""
+)
+target_compile_definitions(
+  "gstcef" PUBLIC
+  "-DCEF_LOCALES_DIR=\"${CEF_SUBPROCESS_BASE_PATH}/locales\""
+)
+
 set_target_properties("gstcef" PROPERTIES INSTALL_RPATH "$ORIGIN")
 set_target_properties("gstcef" PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
 set_target_properties("gstcef" PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CEF_TARGET_OUT_DIR})
@@ -82,3 +103,14 @@ set_target_properties("gstcef" PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CEF_TARGET_
 
 COPY_FILES("gstcef" "${CEF_BINARY_FILES}" "${CEF_BINARY_DIR}" "${CEF_TARGET_OUT_DIR}")
 COPY_FILES("gstcef" "${CEF_RESOURCE_FILES}" "${CEF_RESOURCE_DIR}" "${CEF_TARGET_OUT_DIR}")
+
+if (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  install(
+    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/
+    DESTINATION .
+  )
+  install(
+    TARGETS "gstcef" "gstcefsubprocess"
+    DESTINATION .
+  )
+endif()

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..
 make
 ```
 
+## Build + install
+You can build for install using any path. If you install inside GStreamer plugin path there is no need to set `GST_PLUGIN_PATH` variable.
+
+```
+mkdir build && cd build
+cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/lib/x86_64-linux-gnu/gstreamer-1.0/cefsrc/ ..
+make
+make install
+```
+
 ## Run
 
 The element can then be tested with:


### PR DESCRIPTION
Related to talks on #28
I ended up implementing `make install` functionality instead of some custom variable. For example to install in `/usr/lib/x86_64-linux-gnu/gstreamer-1.0/gstcef/` you could run as follows
```shell
cmake \
      -DCMAKE_INSTALL_PREFIX=/usr/lib/x86_64-linux-gnu/gstreamer-1.0/gstcef/ \
      -DCMAKE_BUILD_TYPE=Release \
      -G"Unix Makefiles" .. && make && sudo make install
```
If that is GStreamer plugin path (can be a subdirectory as gstreamer recurses by default) then there is no need to set `GST_PLUGIN_PATH` variable, if not, you can simply set the variable to the install path as in `GST_PLUGIN_PATH=/usr/lib/x86_64-linux-gnu/gstreamer-1.0/gstcef/:$GST_PLUGIN_PATH` instead of using the `build/Release` path.

If `CMAKE_INSTALL_PREFIX` is not defined when building it will behave just like now (can't be installed and won't work if moved)

Tested on Debian (bullseye) and Ubuntu (focal) only.
