### PR TITLE
use plugin location to find gstcefsubprocess bin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,11 @@ project(gstcef)
 
 set_property(GLOBAL PROPERTY OS_FOLDERS ON)
 
+if(POLICY CMP0074)
+    #policy for <PackageName>_ROOT variables
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 set(CEF_VERSION "88.2.9+g5c8711a+chromium-88.0.4324.182")
 set(CEF_ESCAPED_VERSION "88.2.9%2Bg5c8711a%2Bchromium-88.0.4324.182")
 
@@ -73,12 +78,19 @@ SET_LIBRARY_TARGET_PROPERTIES("gstcef")
 add_dependencies("gstcef" libcef_dll_wrapper)
 target_link_libraries("gstcef" libcef_lib libcef_dll_wrapper ${CEF_STANDARD_LIBS} ${GST_LIBRARIES})
 target_include_directories("gstcef" PUBLIC ${GST_INCLUDE_DIRS})
-target_compile_definitions("gstcef" PUBLIC "-DCEF_SUBPROCESS_PATH=\"$<TARGET_FILE:gstcefsubprocess>\"")
-target_compile_definitions("gstcef" PUBLIC "-DCEF_LOCALES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/locales\"")
+
 set_target_properties("gstcef" PROPERTIES INSTALL_RPATH "$ORIGIN")
 set_target_properties("gstcef" PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
 set_target_properties("gstcef" PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CEF_TARGET_OUT_DIR})
 
-
 COPY_FILES("gstcef" "${CEF_BINARY_FILES}" "${CEF_BINARY_DIR}" "${CEF_TARGET_OUT_DIR}")
 COPY_FILES("gstcef" "${CEF_RESOURCE_FILES}" "${CEF_RESOURCE_DIR}" "${CEF_TARGET_OUT_DIR}")
+
+install(
+  DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/
+  DESTINATION .
+)
+install(
+  TARGETS "gstcef" "gstcefsubprocess"
+  DESTINATION .
+)

--- a/gstcefsrc.cc
+++ b/gstcefsrc.cc
@@ -51,6 +51,13 @@ GST_STATIC_PAD_TEMPLATE ("src",
     GST_STATIC_CAPS (CEF_VIDEO_CAPS)
     );
 
+gchar* get_plugin_base_path () {
+  GstPlugin *plugin = gst_registry_find_plugin(gst_registry_get(), "cef");
+  gchar* base_path = g_path_get_dirname(gst_plugin_get_filename(plugin));
+  gst_object_unref(plugin);
+  return base_path;
+}
+
 class RenderHandler : public CefRenderHandler
 {
   public:
@@ -389,9 +396,16 @@ run_cef (GstCefSrc *src)
 
   GST_INFO  ("Initializing CEF");
 
-  /* FIXME: won't work installed */
-  CefString(&settings.browser_subprocess_path).FromASCII(CEF_SUBPROCESS_PATH);
-  CefString(&settings.locales_dir_path).FromASCII(CEF_LOCALES_DIR);
+  gchar* base_path = get_plugin_base_path();
+  gchar* browser_subprocess_path = g_build_filename(base_path, "gstcefsubprocess", NULL);
+  gchar* locales_dir_path = g_build_filename(base_path, "locales", NULL);
+
+  CefString(&settings.browser_subprocess_path).FromASCII(browser_subprocess_path);
+  CefString(&settings.locales_dir_path).FromASCII(locales_dir_path);
+
+  g_free(base_path);
+  g_free(browser_subprocess_path);
+  g_free(locales_dir_path);
 
   app = new App(src);
 


### PR DESCRIPTION
Related to talks on #28 and #30
Removes `target_compile_definitions` for `gstcefsubprocess` and `locales` paths in favor of inferring path based on plugin location.