### PR TITLE
Generic chrome parameters passing

### DIFF
--- a/gstcefsrc.cc
+++ b/gstcefsrc.cc
@@ -36,6 +36,7 @@ enum
   PROP_URL,
   PROP_GPU,
   PROP_CHROMIUM_DEBUG_PORT,
+  PROP_CHROME_EXTRA_FLAGS
 };
 
 #define gst_cef_src_parent_class parent_class
@@ -328,6 +329,22 @@ class App : public CefApp
 
     if (src->chromium_debug_port >= 0) {
       command_line->AppendSwitchWithValue("remote-debugging-port", g_strdup_printf ("%i", src->chromium_debug_port));
+    }
+    if (src->chrome_extra_flags) {
+      gchar **flagsList = g_strsplit((const gchar *) src->chrome_extra_flags, ",", -1);
+      guint i;
+      for (i = 0; i < g_strv_length(flagsList); i++) {
+        gchar **switchValue = g_strsplit((const gchar *) flagsList[i], "=", -1);
+        if (g_strv_length(switchValue) > 1) {
+          GST_INFO("Adding SwitchWithValue %s=%s", switchValue[0], switchValue[1]);
+          command_line->AppendSwitchWithValue(switchValue[0], switchValue[1]);
+          g_strfreev(switchValue);
+        } else {
+          GST_INFO("Adding flag %s", flagsList[i]);
+          command_line->AppendSwitch(flagsList[i]);
+        }
+      }
+      g_strfreev(flagsList);
     }
   }
 
@@ -654,6 +671,11 @@ gst_cef_src_set_property (GObject * object, guint prop_id, const GValue * value,
 
       break;
     }
+    case PROP_CHROME_EXTRA_FLAGS: {
+      const gchar* chrome_extra_flags = g_value_get_string (value);
+      src->chrome_extra_flags = g_strdup(chrome_extra_flags);
+      break;
+    }
     case PROP_GPU:
     {
       src->gpu = g_value_get_boolean (value);
@@ -679,6 +701,9 @@ gst_cef_src_get_property (GObject * object, guint prop_id, GValue * value,
   switch (prop_id) {
     case PROP_URL:
       g_value_set_string (value, src->url);
+      break;
+    case PROP_CHROME_EXTRA_FLAGS:
+      g_value_set_string (value, src->chrome_extra_flags);
       break;
     case PROP_GPU:
       g_value_set_boolean (value, src->gpu);
@@ -752,8 +777,14 @@ gst_cef_src_class_init (GstCefSrcClass * klass)
 
   g_object_class_install_property (gobject_class, PROP_CHROMIUM_DEBUG_PORT,
     g_param_spec_int ("chromium-debug-port", "chromium-debug-port",
-          "Set chromium debug port (-1 = disabled)", -1, G_MAXUINT16,
+          "Set chromium debug port (-1 = disabled) "
+          "deprecated: use chrome-extra-flags instead", -1, G_MAXUINT16,
           DEFAULT_CHROMIUM_DEBUG_PORT, (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | GST_PARAM_MUTABLE_READY)));
+
+  g_object_class_install_property (gobject_class, PROP_CHROME_EXTRA_FLAGS,
+    g_param_spec_string ("chrome-extra-flags", "chrome-extra-flags",
+          "Comma delimiter flags to be passed into chrome (Example: show-fps-counter,remote-debugging-port=9222)",
+          nullptr, (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | GST_PARAM_MUTABLE_READY)));
 
   gst_element_class_set_static_metadata (gstelement_class,
       "Chromium Embedded Framework source", "Source/Video",

--- a/gstcefsrc.h
+++ b/gstcefsrc.h
@@ -37,6 +37,8 @@ struct _GstCefSrc {
   guint64 n_frames;
   gulong cef_work_id;
   gchar *url;
+  gchar *chrome_extra_flags;
+
   gboolean gpu;
   gint chromium_debug_port;
   CefRefPtr<CefBrowser> browser;


### PR DESCRIPTION
Add a new prop called ```chromeExtraFlags```

A comma delimiter flags to be passed into chrome (Example: show-fps-counter,remote-debugging-port=9222)

Example
```base
 gst-launch-1.0  cefsrc url="https://soundcloud.com/platform/sama" chrome-extra-flags=remote-debugging-port=9222  ! ...
 gst-launch-1.0  cefsrc url="https://soundcloud.com/platform/sama" chrome-extra-flags=show-fps-counter  ! ...
 gst-launch-1.0  cefsrc url="https://soundcloud.com/platform/sama" chrome-extra-flags=show-fps-counter,remote-debugging-port=9222  ! ...
```

This eliminate the need for code change every time someone wants to expose a new flag to chrome (Chrome has more than 100 flags)