### PR TITLE
Additional properties

### DIFF
--- a/gstcefsrc.h
+++ b/gstcefsrc.h
@@ -40,6 +40,7 @@ struct _GstCefSrc {
   gchar *chrome_extra_flags;
 
   gboolean gpu;
+  gboolean sandbox;
   gint chromium_debug_port;
   CefRefPtr<CefBrowser> browser;
   CefRefPtr<CefApp> app;

--- a/gstcefsrc.h
+++ b/gstcefsrc.h
@@ -38,7 +38,7 @@ struct _GstCefSrc {
   gulong cef_work_id;
   gchar *url;
   gchar *chrome_extra_flags;
-
+  gchar *js_flags;
   gboolean gpu;
   gboolean sandbox;
   gint chromium_debug_port;


### PR DESCRIPTION
```
commit cf29643a3a59a2374514c47dca1d431505ca5f1e (HEAD -> additional-props)
Author: Philippe Normand <philn@igalia.com>
Date:   Wed Aug 3 12:17:48 2022 +0100

    cefsrc: Add js-flags property
    
    That can allow for instance to disable Wasm support.

commit d16f6c0f3efe40888698a8af2837892b30866005
Author: Philippe Normand <philn@igalia.com>
Date:   Wed Aug 3 12:05:48 2022 +0100

    cefsrc: Add sandbox property
    
    This property allows to enable or disable the Chromium sandbox. By default the
    sandbox is enabled.
```