### PR TITLE
cefbin: Change protocol handler to web+...://

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ run the previous commands with `xvfb-run`:
 `xvfb-run --server-args="-screen 0 1920x1080x60" gst-launch-1.0 ...`
 
 In addition, a wrapper bin is exposed, wrapping cefsrc and cefdemux, and
-handling `web` and `uri` protocols:
+handling `web+http`, `web+https` and `web+file` protocols:
 
 ``` shell
 GST_PLUGIN_PATH=Release:$GST_PLUGIN_PATH gst-launch-1.0 \
@@ -55,5 +55,5 @@ GST_PLUGIN_PATH=Release:$GST_PLUGIN_PATH gst-launch-1.0 \
 ```
 
 ``` shell
-gst-launch-1.0 playbin uri=web://www.soundcloud.com/platform/sama
+gst-launch-1.0 playbin uri=web+https://www.soundcloud.com/platform/sama
 ```

--- a/gstcefbin.cc
+++ b/gstcefbin.cc
@@ -13,7 +13,7 @@ gst_cef_bin_uri_get_type (GType type)
 static const gchar *const *
 gst_cef_bin_get_protocols (GType type)
 {
-  static const gchar *protocols[] = { "web", "cef", NULL };
+  static const gchar *protocols[] = { "web+http", "web+https", "web+file", NULL };
 
   return protocols;
 }
@@ -36,11 +36,20 @@ gst_cef_bin_set_uri (GstURIHandler * handler, const gchar * uristr,
   gboolean res = TRUE;
   gchar *location;
   GstCefBin *self = GST_CEF_BIN (handler);
+  const gchar *protocol;
+  GstUri *uri;
 
-  location = gst_uri_get_location (uristr);
+  protocol = gst_uri_get_protocol (uristr);
+  g_return_val_if_fail (g_str_has_prefix (protocol, "web+"), FALSE);
+
+  uri = gst_uri_from_string (uristr);
+  gst_uri_set_scheme (uri, protocol + 4);
+
+  location = gst_uri_to_string (uri);
 
   g_object_set (self->cefsrc, "url", location, NULL);
 
+  gst_uri_unref (uri);
   g_free (location);
 
   return res;


### PR DESCRIPTION
The URIs this element receives are not compliant with RFC 3986 because they have
2 protocol schemes (web://http://...). So we can't use the GstURI parser in
cefbin, we pass the unparsed URI stripped of the web:// or cef:// prefix to
cefsrc.

V2:

    These URIs are RFC 3986 compliant, so allowing for clean removal of the web+
    prefix before passing the URI to cefsrc.

