### PR TITLE
cmake: Allow user-supplied CEF_VERSION override

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,10 @@ if(POLICY CMP0074)
     cmake_policy(SET CMP0074 NEW)
 endif()
 
-set(CEF_VERSION "103.0.9+gd0bbcbb+chromium-103.0.5060.114")
+if (NOT DEFINED CEF_VERSION)
+  set(CEF_VERSION "103.0.9+gd0bbcbb+chromium-103.0.5060.114")
+endif()
+
 STRING(REGEX REPLACE "\\+" "%2B" CEF_ESCAPED_VERSION ${CEF_VERSION})
 
 # Determine the platform.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ make
 ### Optional CMake variables
 
 - `CEF_VERSION` allows to override the default CEF version
+- `CEF_BUILDS_HOMEPAGE_URL` allows to configure the URL of the website hosting
+  CEF binaries. Default is https://cef-builds.spotifycdn.com
 
 ## Run
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..
 make
 ```
 
+### Optional CMake variables
+
+- `CEF_VERSION` allows to override the default CEF version
+
 ## Run
 
 The element can then be tested with:

--- a/cmake/DownloadCEF.cmake
+++ b/cmake/DownloadCEF.cmake
@@ -14,6 +14,10 @@ function(DownloadCEF platform version escaped_version download_dir)
   set(CEF_DISTRIBUTION "cef_binary_${version}_${platform}")
   set(CEF_DOWNLOAD_DIR "${download_dir}")
 
+  if (NOT DEFINED CEF_BUILDS_HOMEPAGE_URL)
+    set(CEF_BUILDS_HOMEPAGE_URL "https://cef-builds.spotifycdn.com")
+  endif()
+
   # The location where we expect the extracted binary distribution.
   set(CEF_ROOT "${CEF_DOWNLOAD_DIR}/${CEF_DISTRIBUTION}" CACHE INTERNAL "CEF_ROOT")
 
@@ -22,7 +26,7 @@ function(DownloadCEF platform version escaped_version download_dir)
     set(CEF_DOWNLOAD_FILENAME "${CEF_ESCAPED_DISTRIBUTION}.tar.bz2")
     set(CEF_DOWNLOAD_PATH "${CEF_DOWNLOAD_DIR}/${CEF_DOWNLOAD_FILENAME}")
     if(NOT EXISTS "${CEF_DOWNLOAD_PATH}")
-      set(CEF_DOWNLOAD_URL "https://cef-builds.spotifycdn.com/${CEF_DOWNLOAD_FILENAME}")
+      set(CEF_DOWNLOAD_URL "${CEF_BUILDS_HOMEPAGE_URL}/${CEF_DOWNLOAD_FILENAME}")
 
       # Download the SHA1 hash for the binary distribution.
       message(STATUS "Downloading ${CEF_DOWNLOAD_PATH}.sha1...")

--- a/cmake/DownloadCEF.cmake
+++ b/cmake/DownloadCEF.cmake
@@ -31,7 +31,8 @@ function(DownloadCEF platform version escaped_version download_dir)
       # Download the SHA1 hash for the binary distribution.
       message(STATUS "Downloading ${CEF_DOWNLOAD_PATH}.sha1...")
       file(DOWNLOAD "${CEF_DOWNLOAD_URL}.sha1" "${CEF_DOWNLOAD_PATH}.sha1")
-      file(READ "${CEF_DOWNLOAD_PATH}.sha1" CEF_SHA1)
+      file(READ "${CEF_DOWNLOAD_PATH}.sha1" CEF_SHA1_UNSTRIPPED)
+      string(STRIP "${CEF_SHA1_UNSTRIPPED}" CEF_SHA1)
 
       # Download the binary distribution and verify the hash.
       message(STATUS "Downloading ${CEF_DOWNLOAD_PATH}...")


### PR DESCRIPTION
if not provided with `-DCEF_VERSION=...` fallback to hardcoded version number.