### PR TITLE
cefsrc: Apply running time on audio buffers

### DIFF
--- a/gstcefbin.cc
+++ b/gstcefbin.cc
@@ -113,6 +113,11 @@ gst_cef_bin_constructed (GObject *object)
   GstElement *cefsrc, *cefdemux, *vqueue, *aqueue;
   GstPad *srcpad;
 
+
+  gst_bin_set_suppressed_flags (GST_BIN_CAST (self),
+                                static_cast<GstElementFlags>(GST_ELEMENT_FLAG_SOURCE | GST_ELEMENT_FLAG_SINK));
+  GST_OBJECT_FLAG_SET (self, GST_ELEMENT_FLAG_SOURCE);
+
   cefsrc = gst_element_factory_make("cefsrc", "cefsrc");
   cefdemux = gst_element_factory_make("cefdemux", "cefdemux");
   vqueue = gst_element_factory_make("queue", "video-queue");

--- a/gstcefdemux.cc
+++ b/gstcefdemux.cc
@@ -6,7 +6,13 @@
 #define CEF_VIDEO_CAPS "video/x-raw, format=BGRA, width=[1, 2147483647], height=[1, 2147483647], framerate=[1/1, 60/1], pixel-aspect-ratio=1/1"
 #define CEF_AUDIO_CAPS "audio/x-raw, format=F32LE, rate=[1, 2147483647], channels=[1, 2147483647], layout=interleaved"
 
-G_DEFINE_TYPE (GstCefDemux, gst_cef_demux, GST_TYPE_ELEMENT);
+#define GST_CAT_DEFAULT gst_cef_demux_debug
+GST_DEBUG_CATEGORY_STATIC (GST_CAT_DEFAULT);
+
+#define gst_cef_demux_parent_class parent_class
+G_DEFINE_TYPE_WITH_CODE (GstCefDemux, gst_cef_demux, GST_TYPE_ELEMENT,
+                         GST_DEBUG_CATEGORY_INIT (gst_cef_demux_debug, "cefdemux", 0,
+                                                  "cefdemux element"););
 
 static GstStaticPadTemplate gst_cef_demux_sink_template =
 GST_STATIC_PAD_TEMPLATE ("sink",

--- a/gstcefdemux.h
+++ b/gstcefdemux.h
@@ -3,6 +3,7 @@
 
 #include <gst/gst.h>
 #include <gst/base/gstflowcombiner.h>
+#include <gst/audio/audio.h>
 
 G_BEGIN_DECLS
 
@@ -26,13 +27,14 @@ struct _GstCefDemux {
   gboolean need_stream_start;
   gboolean need_caps;
   gboolean need_segment;
+  gboolean need_discont;
   GstPad *vsrcpad;
   GstPad *asrcpad;
   GList *cef_audio_stream_start_events;
   GstEvent *vcaps_event;
   GstFlowCombiner *flow_combiner;
   GstClockTime last_audio_time;
-  GstClockTime ts_offset;
+  GstAudioInfo audio_info;
 };
 
 struct _GstCefDemuxClass {

--- a/gstcefsrc.cc
+++ b/gstcefsrc.cc
@@ -182,7 +182,6 @@ class AudioHandler : public CefAudioHandler
 
     mRate = params.sample_rate;
     mChannels = channels;
-    mCurrentTime = GST_CLOCK_TIME_NONE;
 
     GST_OBJECT_LOCK (mElement);
     mElement->audio_events = g_list_append (mElement->audio_events, event);
@@ -214,14 +213,7 @@ class AudioHandler : public CefAudioHandler
 
     GST_OBJECT_LOCK (mElement);
 
-    if (!GST_CLOCK_TIME_IS_VALID (mCurrentTime)) {
-      mCurrentTime = gst_util_uint64_scale (mElement->n_frames,
-          mElement->vinfo.fps_d * GST_SECOND, mElement->vinfo.fps_n);
-    }
-
-    GST_BUFFER_PTS (buf) = mCurrentTime;
     GST_BUFFER_DURATION (buf) = gst_util_uint64_scale (frames, GST_SECOND, mRate);
-    mCurrentTime += GST_BUFFER_DURATION (buf);
 
     if (!mElement->audio_buffers) {
       mElement->audio_buffers = gst_buffer_list_new();
@@ -245,7 +237,6 @@ class AudioHandler : public CefAudioHandler
   private:
 
     GstCefSrc *mElement;
-    GstClockTime mCurrentTime;
     gint mRate;
     gint mChannels;
     IMPLEMENT_REFCOUNTING(AudioHandler);


### PR DESCRIPTION
Also add an audio meta to buffers, for good measure, and set discont flag when needed. This should help with A/V sync issues and audio cracks reported in #59.