### PR TITLE
CI: Install libunwind

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
+          sudo apt-get install --yes libunwind-dev
           sudo apt-get install --yes libgstreamer1.0-0 libgstreamer-plugins-base1.0-dev
 
       - name: Cache


### PR DESCRIPTION
Otherwise the Ubuntu 22.04 workflow fails with this error:

The following packages have unmet dependencies:
 libunwind-14-dev : Breaks: libunwind-dev but 1.3.2-2build2 is to be installed
E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.