### PR TITLE
Revert "fix builds on macos arm64 and pay attention to USE_SANDBOX flag"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,11 +19,7 @@ STRING(REGEX REPLACE "\\+" "%2B" CEF_ESCAPED_VERSION ${CEF_VERSION})
 
 # Determine the platform.
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-  if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
-    set(CEF_PLATFORM "macosarm64")
-  else()
-    set(CEF_PLATFORM "macosx64")
-  endif()
+  set(CEF_PLATFORM "macosx64")
 elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
   if(CMAKE_SIZEOF_VOID_P MATCHES 8)
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm" OR CMAKE_SYSTEM_PROCESSOR MATCHES "aarch")
@@ -71,11 +67,7 @@ pkg_check_modules(GST REQUIRED gstreamer-1.0
                   gstreamer-video-1.0
                   gstreamer-audio-1.0)
 
-if(USE_SANDBOX)
-  ADD_LOGICAL_TARGET("libcef_lib" "${CEF_SANDBOX_LIB_DEBUG}" "${CEF_SANDBOX_LIB_RELEASE}")
-else()
-  ADD_LOGICAL_TARGET("libcef_lib" "${CEF_LIB_DEBUG}" "${CEF_LIB_RELEASE}")
-endif()
+ADD_LOGICAL_TARGET("libcef_lib" "${CEF_LIB_DEBUG}" "${CEF_LIB_RELEASE}")
 
 SET_CEF_TARGET_OUT_DIR()
 


### PR DESCRIPTION
Reverts centricular/gstcefsrc#67 due to the issue #68