### PR TITLE
Fix bad audio metadata (issues #73)

### DIFF
--- a/gstcefdemux.cc
+++ b/gstcefdemux.cc
@@ -149,7 +149,9 @@ gst_cef_demux_push_audio_buffer (GstBuffer **buffer, guint idx, AudioPushData *p
   GST_BUFFER_DTS (*buffer) = push_data->demux->last_audio_time;
   GST_BUFFER_PTS (*buffer) = push_data->demux->last_audio_time;
 
-  gst_buffer_add_audio_meta (*buffer, &push_data->demux->audio_info, gst_buffer_get_size (*buffer), NULL);
+  gst_buffer_add_audio_meta (*buffer, &push_data->demux->audio_info, 
+                             gst_buffer_get_size (*buffer) / GST_AUDIO_INFO_BPS (&push_data->demux->audio_info), 
+                             NULL);
 
   GST_BUFFER_FLAG_UNSET (*buffer, GST_BUFFER_FLAG_DISCONT);
   if (push_data->demux->need_discont) {


### PR DESCRIPTION
It looks like issue #73 was never addressed. This PR has the suggested fix.