### PR TITLE
Add javascript signalling

### DIFF
--- a/gstcefsrc.cc
+++ b/gstcefsrc.cc
@@ -1288,7 +1288,10 @@ gst_cef_src_class_init (GstCefSrcClass * klass)
           DEFAULT_SANDBOX, (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | GST_PARAM_MUTABLE_READY)));
   g_object_class_install_property (gobject_class, PROP_LISTEN_FOR_JS_SIGNAL,
     g_param_spec_boolean ("listen-for-js-signals", "listen-for-js-signals",
-          "Listen and respond to signals sent from javascript: window.gstSendMsg({request: \"ready|eos\", ...})",
+          "Listen and respond to signals sent from javascript: "
+          "window.gstSendMsg({request: \"ready|eos\", ...}) - "
+          "see [README](https://github.com/centricular/gstcefsrc?tab=readme-ov-file#javascript-signals) "
+          "for more detail",
           DEFAULT_LISTEN_FOR_JS_SIGNALS, (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | GST_PARAM_MUTABLE_READY)));
 
   g_object_class_install_property (gobject_class, PROP_JS_FLAGS,

--- a/gstcefsrc.cc
+++ b/gstcefsrc.cc
@@ -326,17 +326,17 @@ class BrowserClient :
 {
   public:
 
-    BrowserClient(CefRefPtr<CefRenderHandler> rptr, CefRefPtr<CefAudioHandler> aptr, CefRefPtr<CefRequestHandler> rqptr, CefRefPtr<CefDisplayHandler> display_handler, GstCefSrc *element) :
-        render_handler(rptr),
-        audio_handler(aptr),
-        request_handler(rqptr),
-        display_handler(display_handler),
-        mElement(element)
+    BrowserClient(GstCefSrc *element) : mElement(element)
     {
+      this->render_handler = new RenderHandler(element);
+      this->audio_handler = new AudioHandler(element);
+      this->request_handler = new RequestHandler(element);
+      this->display_handler = new DisplayHandler(element);
     }
 
-    virtual CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override {
-        return this;
+    virtual CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override
+    {
+      return this;
     }
 
     virtual CefRefPtr<CefRenderHandler> GetRenderHandler() override
@@ -769,11 +769,7 @@ gst_cef_src_start(GstBaseSrc *base_src)
 {
   gboolean ret = FALSE;
   GstCefSrc *src = GST_CEF_SRC (base_src);
-  CefRefPtr<BrowserClient> browserClient;
-  CefRefPtr<RenderHandler> renderHandler = new RenderHandler(src);
-  CefRefPtr<AudioHandler> audioHandler = new AudioHandler(src);
-  CefRefPtr<RequestHandler> requestHandler = new RequestHandler(src);
-  CefRefPtr<DisplayHandler> displayHandler = new DisplayHandler(src);
+  CefRefPtr<BrowserClient> browserClient = new BrowserClient(src);
 
   /* Make sure CEF is initialized before posting a task */
   g_mutex_lock (&init_lock);
@@ -787,8 +783,6 @@ gst_cef_src_start(GstBaseSrc *base_src)
   GST_OBJECT_LOCK (src);
   src->n_frames = 0;
   GST_OBJECT_UNLOCK (src);
-
-  browserClient = new BrowserClient(renderHandler, audioHandler, requestHandler, displayHandler, src);
 #ifdef __APPLE__
   if (pthread_main_np()) {
     /* in the main thread as per Cocoa */

--- a/gstcefsrc.cc
+++ b/gstcefsrc.cc
@@ -1,4 +1,7 @@
 #include <cstdio>
+#include <sstream>
+#include <string>
+
 #ifdef __APPLE__
 #include <memory>
 #include <string>
@@ -38,12 +41,13 @@ GST_DEBUG_CATEGORY_STATIC (cef_console_debug);
 #else
 #define DEFAULT_SANDBOX FALSE
 #endif
+#define DEFAULT_LISTEN_FOR_JS_SIGNALS FALSE
 
 using CefStatus = enum : guint8 {
   // CEF was either unloaded successfully or not yet loaded.
   CEF_STATUS_NOT_LOADED = 0U,
   // Blocks other elements from initializing CEF is it's already in progress.
-  CEF_STATUS_INITIALIZING = 1U,
+  CEF_STATUS_INITIALIZING = 1U << 1U,
   // CEF's initialization process has completed successfully.
   CEF_STATUS_INITIALIZED = 1U << 2U,
   // No CEF elements will be allowed to complete initialization.
@@ -55,7 +59,8 @@ using CefStatus = enum : guint8 {
 };
 static CefStatus cef_status = CEF_STATUS_NOT_LOADED;
 static const guint8 CEF_STATUS_MASK_INITIALIZED = CEF_STATUS_FAILURE | CEF_STATUS_INITIALIZED;
-static const guint8 CEF_STATUS_MASK_TRANSITIONING = CEF_STATUS_SHUTTING_DOWN | CEF_STATUS_INITIALIZING;
+static const guint8 CEF_STATUS_MASK_TRANSITIONING =
+  CEF_STATUS_SHUTTING_DOWN | CEF_STATUS_INITIALIZING;
 
 // Number of running CEF instances. Setting this to 0 must be accompanied
 // with cef_shutdown to prevent leaks on application exit.
@@ -103,6 +108,7 @@ enum
   PROP_CHROMIUM_DEBUG_PORT,
   PROP_CHROME_EXTRA_FLAGS,
   PROP_SANDBOX,
+  PROP_LISTEN_FOR_JS_SIGNAL,
   PROP_JS_FLAGS,
   PROP_LOG_SEVERITY,
   PROP_CEF_CACHE_LOCATION,
@@ -133,31 +139,73 @@ gchar* get_plugin_base_path () {
 
 /** Handlers */
 
+// see https://bitbucket.org/chromiumembedded/cef-project/src/master/examples/message_router
+// and https://bitbucket.org/chromiumembedded/cef/src/master/include/wrapper/cef_message_router.h
+// for details of the message passing infrastructure in CEF
 // Handle messages in the browser process.
 class MessageHandler : public CefMessageRouterBrowserSide::Handler {
  public:
-  explicit MessageHandler(const CefString& startup_url)
-      : startup_url_(startup_url) {}
+  explicit MessageHandler(GstCefSrc* src)
+      : src(src) {}
 
-  // Called due to cefQuery execution in message_router.html.
+  // Called due to gstSendMsg execution in ready_test.html.
   bool OnQuery(CefRefPtr<CefBrowser> browser,
                CefRefPtr<CefFrame> frame,
                int64_t query_id,
                const CefString& request,
                bool persistent,
-               CefRefPtr<Callback> callback) override {
-    // Only handle messages from the startup URL.
-    const std::string& url = frame->GetURL();
-    if (url.find(startup_url_) != 0)
-      return false;
+               CefRefPtr<Callback> callback) override
+  {
+    if (!src) return false;
 
-    const std::string& message_name = request;
-    callback->Success(message_name + " is working");
+    // TODO: do we want to make the incoming payload json??
+    bool success = false;
+
+    if (request == "ready") {
+      g_mutex_lock (&src->state_lock);
+      if (src->state == CEF_SRC_WAITING_FOR_READY) {
+        src->state = CEF_SRC_READY;
+        g_cond_broadcast (&src->state_cond);
+        success = true;
+      } else {
+        std::ostringstream error_msg;
+        error_msg << "error: (" << request << ") - " <<
+          "js ready signal sent with invalid cef state: " << cef_status;
+        GST_WARNING_OBJECT(src, "%s", error_msg.str().c_str());
+        success = false;
+      }
+      g_mutex_unlock (&src->state_lock);
+    } else if (request == "eos") {
+      if (src) {
+        gst_element_send_event(GST_ELEMENT(src), gst_event_new_eos());
+        success = true;
+      }
+    }
+
+    // send json response back to js
+    std::ostringstream response;
+    response <<
+      "{ " <<
+        "\"success\": \"" << (success ? "true" : "false") << "\", " <<
+        "\"cmd\": \"" << request << "\"" <<
+      " }";
+    if (success) {
+      GST_INFO_OBJECT(
+        src, "js signal processed successfully: %s", request.ToString().c_str()
+      );
+      callback->Success(response.str());
+    } else {
+      GST_WARNING_OBJECT(
+        src, "js signal processing error: %s", request.ToString().c_str()
+      );
+      callback->Failure(0, response.str());
+    }
+
     return true;
   }
 
  private:
-  const CefString startup_url_;
+  GstCefSrc* src;
 
   DISALLOW_COPY_AND_ASSIGN(MessageHandler);
 };
@@ -379,12 +427,14 @@ class BrowserClient :
     {
       CEF_REQUIRE_UI_THREAD();
 
-      return browser_msg_router_->OnProcessMessageReceived(
-        browser,
-        frame,
-        source_process,
-        message
-      );
+      return browser_msg_router_
+        ? browser_msg_router_->OnProcessMessageReceived(
+          browser,
+          frame,
+          source_process,
+          message
+        )
+        : false;
     }
 
     // CefLifeSpanHandler Methods:
@@ -392,7 +442,7 @@ class BrowserClient :
     {
       CEF_REQUIRE_UI_THREAD();
 
-      if (!browser_msg_router_) {
+      if (src->listen_for_js_signals && !browser_msg_router_) {
         // Create the browser-side router for query handling.
         CefMessageRouterConfig config;
         config.js_query_function = "gstSendMsg";
@@ -400,7 +450,7 @@ class BrowserClient :
         browser_msg_router_ = CefMessageRouterBrowserSide::Create(config);
 
         // Register handlers with the router.
-        browser_msg_handler_.reset(new MessageHandler(src->url));
+        browser_msg_handler_.reset(new MessageHandler(src));
         browser_msg_router_->AddHandler(browser_msg_handler_.get(), false);
       }
     }
@@ -409,7 +459,7 @@ class BrowserClient :
     {
       src->browser = nullptr;
       g_mutex_lock (&src->state_lock);
-      src->started = FALSE;
+      src->state = CEF_SRC_CLOSED;
       g_cond_signal (&src->state_cond);
       g_mutex_unlock(&src->state_lock);
       g_mutex_lock(&init_lock);
@@ -432,7 +482,7 @@ class BrowserClient :
     {
       CEF_REQUIRE_UI_THREAD();
 
-      browser_msg_router_->OnBeforeBrowse(browser, frame);
+      if (browser_msg_router_) browser_msg_router_->OnBeforeBrowse(browser, frame);
       return false;
     }
 
@@ -440,7 +490,7 @@ class BrowserClient :
     {
       CEF_REQUIRE_UI_THREAD();
       GST_WARNING_OBJECT (src, "Render subprocess terminated, reloading URL!");
-      browser_msg_router_->OnRenderProcessTerminated(browser);
+      if (browser_msg_router_) browser_msg_router_->OnRenderProcessTerminated(browser);
       browser->Reload();
     }
 
@@ -470,7 +520,7 @@ class BrowserClient :
       src->browser = browser;
 
       g_mutex_lock (&src->state_lock);
-      src->started = TRUE;
+      src->state = src->listen_for_js_signals ? CEF_SRC_WAITING_FOR_READY : CEF_SRC_OPEN;
       g_cond_signal (&src->state_cond);
       g_mutex_unlock(&src->state_lock);
     }
@@ -746,7 +796,6 @@ run_cef (GstCefSrc *src)
   cef_status = CEF_STATUS_INITIALIZED;
   g_cond_broadcast (&init_cond);
   g_mutex_unlock (&init_lock);
-
 #ifndef __APPLE__
   CefRunMessageLoop();
   gst_cef_shutdown(nullptr);
@@ -792,7 +841,7 @@ gst_cef_src_change_state(GstElement *src, GstStateChange transition)
       while (cef_status == CEF_STATUS_INITIALIZING)
         g_cond_wait (&init_cond, &init_lock);
 #endif
-      if (cef_status != CEF_STATUS_INITIALIZED) {
+      if (cef_status & ~CEF_STATUS_MASK_INITIALIZED) {
         // BAIL OUT, CEF is not loaded.
         result = GST_STATE_CHANGE_FAILURE;
 #ifndef __APPLE__
@@ -875,12 +924,19 @@ gst_cef_src_start(GstBaseSrc *base_src)
 
     /* And wait for this src's browser to have been created */
     g_mutex_lock(&src->state_lock);
-    while (!src->started)
+    while (!CefSrcStateIsOpen(src->state))
       g_cond_wait (&src->state_cond, &src->state_lock);
     g_mutex_unlock (&src->state_lock);
 #ifdef __APPLE__
   }
 #endif
+
+  if (src->listen_for_js_signals) {
+    g_mutex_lock (&src->state_lock);
+    while (src->state == CEF_SRC_WAITING_FOR_READY)
+      g_cond_wait (&src->state_cond, &src->state_lock);
+    g_mutex_unlock (&src->state_lock);
+  }
 
   ret = src->browser != NULL;
 
@@ -908,7 +964,7 @@ gst_cef_src_stop (GstBaseSrc *base_src)
 #endif
       /* And wait for this src's browser to have been closed */
       g_mutex_lock(&src->state_lock);
-      while (src->started)
+      while (CefSrcStateIsOpen(src->state))
         g_cond_wait (&src->state_cond, &src->state_lock);
       g_mutex_unlock (&src->state_lock);
 #ifdef __APPLE__
@@ -1022,7 +1078,7 @@ gst_cef_src_set_property (GObject * object, guint prop_id, const GValue * value,
       src->url = g_strdup (url);
 
       g_mutex_lock(&src->state_lock);
-      if (src->started) {
+      if (CefSrcStateIsOpen(src->state)) {
         src->browser->GetMainFrame()->LoadURL(src->url);
       }
       g_mutex_unlock(&src->state_lock);
@@ -1047,6 +1103,11 @@ gst_cef_src_set_property (GObject * object, guint prop_id, const GValue * value,
     case PROP_SANDBOX:
     {
       src->sandbox = g_value_get_boolean (value);
+      break;
+    }
+    case PROP_LISTEN_FOR_JS_SIGNAL:
+    {
+      src->listen_for_js_signals = g_value_get_boolean (value);
       break;
     }
     case PROP_JS_FLAGS: {
@@ -1090,6 +1151,9 @@ gst_cef_src_get_property (GObject * object, guint prop_id, GValue * value,
       break;
     case PROP_SANDBOX:
       g_value_set_boolean (value, src->sandbox);
+      break;
+    case PROP_LISTEN_FOR_JS_SIGNAL:
+      g_value_set_boolean (value, src->listen_for_js_signals);
       break;
     case PROP_JS_FLAGS:
       g_value_set_string (value, src->js_flags);
@@ -1135,9 +1199,10 @@ gst_cef_src_init (GstCefSrc * src)
   src->current_buffer = NULL;
   src->audio_buffers = NULL;
   src->audio_events = NULL;
-  src->started = FALSE;
+  src->state = CEF_SRC_CLOSED;
   src->chromium_debug_port = DEFAULT_CHROMIUM_DEBUG_PORT;
   src->sandbox = DEFAULT_SANDBOX;
+  src->listen_for_js_signals = DEFAULT_LISTEN_FOR_JS_SIGNALS;
   src->js_flags = NULL;
   src->log_severity = DEFAULT_LOG_SEVERITY;
   src->cef_cache_location = NULL;
@@ -1187,6 +1252,10 @@ gst_cef_src_class_init (GstCefSrcClass * klass)
     g_param_spec_boolean ("sandbox", "sandbox",
           "Toggle chromium sandboxing capabilities",
           DEFAULT_SANDBOX, (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | GST_PARAM_MUTABLE_READY)));
+  g_object_class_install_property (gobject_class, PROP_LISTEN_FOR_JS_SIGNAL,
+    g_param_spec_boolean ("listen-for-js-signals", "listen-for-js-signals",
+          "Listen and respond to signals sent from javascript: window.gstSendMsg({request: \"ready|eos\", ...})",
+          DEFAULT_LISTEN_FOR_JS_SIGNALS, (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | GST_PARAM_MUTABLE_READY)));
 
   g_object_class_install_property (gobject_class, PROP_JS_FLAGS,
     g_param_spec_string ("js-flags", "js-flags",

--- a/gstcefsrc.cc
+++ b/gstcefsrc.cc
@@ -414,17 +414,17 @@ void BrowserClient::MakeBrowser(int arg)
   g_mutex_unlock(&mElement->state_lock);
 }
 
-App::App(GstCefSrc *src) : src(src)
+BrowserApp::BrowserApp(GstCefSrc *src) : src(src)
 {
 }
 
-CefRefPtr<CefBrowserProcessHandler> App::GetBrowserProcessHandler()
+CefRefPtr<CefBrowserProcessHandler> BrowserApp::GetBrowserProcessHandler()
 {
   return this;
 }
 
 #ifdef __APPLE__
-void App::OnScheduleMessagePumpWork(int64_t delay_ms)
+void BrowserApp::OnScheduleMessagePumpWork(int64_t delay_ms)
 {
   static const int64_t kMaxTimerDelay = 1000.0 / 60.0;
 
@@ -453,7 +453,7 @@ void App::OnScheduleMessagePumpWork(int64_t delay_ms)
 }
 #endif
 
-void App::OnBeforeCommandLineProcessing(const CefString &process_type,
+void BrowserApp::OnBeforeCommandLineProcessing(const CefString &process_type,
                                              CefRefPtr<CefCommandLine> command_line)
 {
     command_line->AppendSwitchWithValue("autoplay-policy", "no-user-gesture-required");
@@ -566,7 +566,7 @@ run_cef (GstCefSrc *src)
 #endif
 
   CefSettings settings;
-  CefRefPtr<App> app;
+  CefRefPtr<BrowserApp> app;
   CefWindowInfo window_info;
   CefBrowserSettings browserSettings;
 
@@ -646,7 +646,7 @@ run_cef (GstCefSrc *src)
   g_free(base_path);
   g_free(locales_dir_path);
 
-  app = new App(src);
+  app = new BrowserApp(src);
 
   if (!CefInitialize(args, settings, app, nullptr)) {
     GST_ERROR ("Failed to initialize CEF");

--- a/gstcefsrc.h
+++ b/gstcefsrc.h
@@ -57,9 +57,9 @@ struct _GstCefSrcClass {
   GstPushSrcClass parent_class;
 };
 
-class App : public CefApp, public CefBrowserProcessHandler {
+class BrowserApp : public CefApp, public CefBrowserProcessHandler {
 public:
-  App(GstCefSrc *src);
+  BrowserApp(GstCefSrc *src);
 
   void OnBeforeCommandLineProcessing(const CefString &process_type,
                                      CefRefPtr<CefCommandLine> command_line) override;
@@ -69,7 +69,7 @@ public:
   void OnScheduleMessagePumpWork(int64_t delay_ms) override;
 #endif
 private:
-  IMPLEMENT_REFCOUNTING(App);
+  IMPLEMENT_REFCOUNTING(BrowserApp);
   GstCefSrc *src;
 };
 

--- a/gstcefsrc.h
+++ b/gstcefsrc.h
@@ -29,6 +29,20 @@ G_BEGIN_DECLS
 typedef struct _GstCefSrc GstCefSrc;
 typedef struct _GstCefSrcClass GstCefSrcClass;
 
+typedef enum : guint8 {
+  // browser app not yet initialized
+  CEF_SRC_CLOSED            = 0,
+  // browser app initialized
+  CEF_SRC_OPEN              = 1,
+  // following states only possible if `listen_for_js_signals`:
+  // waiting for CEF browser to send "ready" message (using window.gstSendMsg)
+  CEF_SRC_WAITING_FOR_READY = 2,
+  // received ready signal from webpage
+  CEF_SRC_READY             = 3,
+} CefSrcState;
+
+#define CefSrcStateIsOpen(state) (state >= CEF_SRC_OPEN)
+
 struct _GstCefSrc {
   GstPushSrc parent;
   GstBuffer *current_buffer;
@@ -44,13 +58,14 @@ struct _GstCefSrc {
   gchar *cef_cache_location;
   gboolean gpu;
   gboolean sandbox;
+  gboolean listen_for_js_signals;
   gint chromium_debug_port;
   CefRefPtr<CefBrowser> browser;
   CefRefPtr<CefApp> app;
 
   GCond state_cond;
   GMutex state_lock;
-  gboolean started;
+  CefSrcState state;
 };
 
 struct _GstCefSrcClass {

--- a/gstcefsubprocess.cc
+++ b/gstcefsubprocess.cc
@@ -17,6 +17,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
+#include "include/wrapper/cef_message_router.h"
 #include <include/cef_app.h>
 #include <glib.h>
 
@@ -27,6 +28,98 @@
 #if !defined(__APPLE__) && defined(GST_CEF_USE_SANDBOX)
 #include "include/cef_sandbox_mac.h"
 #endif
+
+
+enum ProcessType {
+  PROCESS_TYPE_BROWSER,
+  PROCESS_TYPE_RENDERER,
+  PROCESS_TYPE_OTHER,
+};
+
+// These flags must match the Chromium values.
+const char kProcessType[] = "type";
+const char kRendererProcess[] = "renderer";
+#if defined(OS_LINUX)
+const char kZygoteProcess[] = "zygote";
+#endif
+
+CefRefPtr<CefCommandLine> CreateCommandLine(const CefMainArgs& main_args) {
+  CefRefPtr<CefCommandLine> command_line = CefCommandLine::CreateCommandLine();
+#if defined(OS_WIN)
+  command_line->InitFromString(::GetCommandLineW());
+#else
+  command_line->InitFromArgv(main_args.argc, main_args.argv);
+#endif
+  return command_line;
+}
+
+ProcessType GetProcessType(const CefMainArgs& main_args) {
+  // Create a temporary CommandLine object.
+  CefRefPtr<CefCommandLine> command_line = CreateCommandLine(main_args);
+  // The command-line flag won't be specified for the browser process.
+  if (!command_line->HasSwitch(kProcessType))
+    return PROCESS_TYPE_BROWSER;
+
+  const std::string& process_type = command_line->GetSwitchValue(kProcessType);
+  if (process_type == kRendererProcess)
+    return PROCESS_TYPE_RENDERER;
+
+#if defined(OS_LINUX)
+  // On Linux the zygote process is used to spawn other process types. Since we
+  // don't know what type of process it will be we give it the renderer app.
+  if (process_type == kZygoteProcess)
+    return PROCESS_TYPE_RENDERER;
+#endif
+
+  return PROCESS_TYPE_OTHER;
+}
+
+// Implementation of CefApp for the renderer process.
+class RendererApp : public CefApp, public CefRenderProcessHandler {
+ public:
+  RendererApp() {}
+
+  // CefApp methods:
+  CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler() override {
+    return this;
+  }
+
+  // CefRenderProcessHandler methods:
+  void OnWebKitInitialized() override {
+    // Create the renderer-side router for query handling.
+    CefMessageRouterConfig config;
+    config.js_query_function = "gstSendMsg";
+    config.js_cancel_function = "gstCancelMsg";
+    renderer_msg_router_ = CefMessageRouterRendererSide::Create(config);
+  }
+
+  void OnContextCreated(CefRefPtr<CefBrowser> browser,
+                        CefRefPtr<CefFrame> frame,
+                        CefRefPtr<CefV8Context> context) override {
+    renderer_msg_router_->OnContextCreated(browser, frame, context);
+  }
+
+  void OnContextReleased(CefRefPtr<CefBrowser> browser,
+                         CefRefPtr<CefFrame> frame,
+                         CefRefPtr<CefV8Context> context) override {
+    renderer_msg_router_->OnContextReleased(browser, frame, context);
+  }
+
+  bool OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
+                                CefRefPtr<CefFrame> frame,
+                                CefProcessId source_process,
+                                CefRefPtr<CefProcessMessage> message) override {
+    return renderer_msg_router_->OnProcessMessageReceived(
+      browser, frame, source_process, message);
+  }
+
+ private:
+  // Handles the renderer side of query routing.
+  CefRefPtr<CefMessageRouterRendererSide> renderer_msg_router_;
+
+  IMPLEMENT_REFCOUNTING(RendererApp);
+  DISALLOW_COPY_AND_ASSIGN(RendererApp);
+};
 
 int main(int argc, char * argv[])
 {
@@ -57,5 +150,19 @@ int main(int argc, char * argv[])
   }
 #endif
 
-  return CefExecuteProcess(args, nullptr, nullptr);
+  // NB: this function is executed on new thread per new CEF "process" / app
+  CefRefPtr<CefApp> app = nullptr;
+  switch (GetProcessType(args)) {
+    case PROCESS_TYPE_RENDERER:
+      app = new RendererApp();
+      break;
+    case PROCESS_TYPE_BROWSER:
+      // browser app created in main thread / executable
+      break;
+    case PROCESS_TYPE_OTHER:
+      // this is unused??
+      break;
+  }
+
+  return CefExecuteProcess(args, app, nullptr);
 }

--- a/html/ready_test.html
+++ b/html/ready_test.html
@@ -1,29 +1,93 @@
 <html>
   <head>
     <title>Signals Sample</title>
+    <style>
+      body {
+        overflow: hidden;
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .wrapper {
+        width: 30%;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        justify-content: center;
+        align-items: center;
+        background-color: white;
+      }
+
+      .container {
+        width: 100%;
+        text-align: left;
+        font-size: large;
+        font-weight: bold;
+        padding: 1rem;
+      }
+
+      .result {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        padding: 1rem;
+      }
+
+      .result-title {
+        font-weight: bold;
+        font-size: medium;
+      }
+      .result-text {
+        font-weight: normal;
+        font-size: medium;
+      }
+
+      .progress-bar {
+        width: 80%;
+        margin-top: 1rem;
+        background-color: #e0e0e0;
+        border-radius: 3px;
+        box-shadow: inset 0 1px 3px rgba(0, 0, 0, .2);
+      }
+
+      .progress-bar-fill {
+        display: block;
+        height: 22px;
+        background-color: #659cef;
+        border-radius: 3px;
+
+        transition: width 100ms ease-out;
+      }
+    </style>
     <script language="JavaScript">
       const tStart = 3; // s
       const tBad = 1; // s
       const tDur = 5; // s
       const dt = 0.1; // s
+      const totalTime = tStart + tDur;
       let time = 0;
-      let remTime = tStart + tDur;
+      let remTime = totalTime;
 
       function sendMessage(msg) {
         // Send "command" to renderer process in CEF, which gets routed to
         // the main thread
+        const signals = document.getElementById("signals");
+        const response = document.getElementById("response");
+
+        showResult(signals, msg, "msg");
+
         window.gstSendMsg({
           request: msg,
           onSuccess: function(response) {
             try {
               const json = JSON.parse(response);
-              showResult(json, false);
+              showResult(response, json, "response");
               if (json && json.success && json.cmd === "ready") {
-                console.log("sending eos signal in 5s...");
-                setTimeout(() => {
-                  console.log("sending eos signal");
-                  sendMessage("eos");
-                }, tDur * 1000);
+                console.log("got response to READY from cefsrc");
               }
             } catch (e) {
               console.error("parse error", e);
@@ -32,7 +96,7 @@
           onFailure: function(error_code, error_message) {
             try {
               const json = JSON.parse(error_message);
-              showResult(json, true);
+              showResult(response, JSON.stringify(json), "error");
             } catch (e) {
             console.error("parse error", e);
             }
@@ -40,17 +104,25 @@
         });
       }
 
-      function showResult(resultJson, isError) {
-        document.getElementById("result").innerHTML +=
-          "<br />" + `${isError ? "error" : "response"} at ${time.toFixed(1)}s: ` + "<br />" +
-          JSON.stringify(resultJson, null, 4);
+      function showResult(element, msg, title) {
+        element.innerHTML +=
+          "<br />" +
+          `<div class="result">` +
+            `<div class="result-title">${title} at ${(time + dt).toFixed(1)}s: </div>` +
+            `<div class="result-text">${msg}</div>` +
+          `</div>`;
       }
 
-      console.log("sending 'ready' signal in 3s...");
+      console.log(`sending 'ready' signal in ${tStart}s...`);
       setTimeout(() => {
         console.log("sending 'ready' signal");
         sendMessage("ready");
       }, tStart * 1000);
+
+      setTimeout(() => {
+        console.log("sending eos signal");
+        sendMessage("eos");
+      }, (tStart + tDur) * 1000);
 
       setTimeout(() => {
         console.log("sending test 'bad' signal");
@@ -61,30 +133,26 @@
         document.getElementById("timer").innerHTML =
           `countdown: ${remTime.toFixed(1)}s` +  "<br />" +
           `running: ${time.toFixed(1)}s`;
+        document.getElementById("progress").style.width =
+          `${Math.max((remTime / totalTime), 0) * 100}%`;
 
         time += dt;
         remTime -= dt;
       }, dt * 1000);
     </script>
   </head>
-  <body
-    style="
-      overflow: hidden;
-      position: absolute;
-      width: 100%;
-      height: 100%;
-      display: flex;
-      flex-direction: column;
-      gap: 20px;
-      justify-content: center;
-      align-items: center;
-      background-color: white;
-    "
-  >
-    <div id="result" style="background-color: aqua; width: 30%; text-align: center;">
-      Responses:
-    </div>
-    <div id="timer" style="background-color: hotpink; width: 30%; text-align: center;"></div>
+  <body>
+    <div class="wrapper">
+      <div id="signals" class="container" style="background-color: #32a852;">
+        Signals:
+      </div>
+      <div id="response" class="container" style="background-color: #8c8edb;">
+        Responses:
+      </div>
+      <div id="timer" class="container" style="background-color: #ff775c;"></div>
+      <div class="progress-bar">
+        <span id="progress" class="progress-bar-fill" style="width: 100%;"></span>
+      </div>
     </div>
   </body>
 </html>

--- a/html/ready_test.html
+++ b/html/ready_test.html
@@ -1,0 +1,90 @@
+<html>
+  <head>
+    <title>Signals Sample</title>
+    <script language="JavaScript">
+      const tStart = 3; // s
+      const tBad = 1; // s
+      const tDur = 5; // s
+      const dt = 0.1; // s
+      let time = 0;
+      let remTime = tStart + tDur;
+
+      function sendMessage(msg) {
+        // Send "command" to renderer process in CEF, which gets routed to
+        // the main thread
+        window.gstSendMsg({
+          request: msg,
+          onSuccess: function(response) {
+            try {
+              const json = JSON.parse(response);
+              showResult(json, false);
+              if (json && json.success && json.cmd === "ready") {
+                console.log("sending eos signal in 5s...");
+                setTimeout(() => {
+                  console.log("sending eos signal");
+                  sendMessage("eos");
+                }, tDur * 1000);
+              }
+            } catch (e) {
+              console.error("parse error", e);
+            }
+          },
+          onFailure: function(error_code, error_message) {
+            try {
+              const json = JSON.parse(error_message);
+              showResult(json, true);
+            } catch (e) {
+            console.error("parse error", e);
+            }
+          }
+        });
+      }
+
+      function showResult(resultJson, isError) {
+        document.getElementById("result").innerHTML +=
+          "<br />" + `${isError ? "error" : "response"} at ${time.toFixed(1)}s: ` + "<br />" +
+          JSON.stringify(resultJson, null, 4);
+      }
+
+      console.log("sending 'ready' signal in 3s...");
+      setTimeout(() => {
+        console.log("sending 'ready' signal");
+        sendMessage("ready");
+      }, tStart * 1000);
+
+      setTimeout(() => {
+        console.log("sending test 'bad' signal");
+        sendMessage("bad");
+      }, (tStart + tBad) * 1000);
+
+      setInterval(() => {
+        document.getElementById("timer").innerHTML =
+          `countdown: ${remTime.toFixed(1)}s` +  "<br />" +
+          `running: ${time.toFixed(1)}s`;
+
+        time += dt;
+        remTime -= dt;
+      }, dt * 1000);
+    </script>
+  </head>
+  <body
+    style="
+      overflow: hidden;
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+      justify-content: center;
+      align-items: center;
+      background-color: white;
+    "
+  >
+    <div id="result" style="background-color: aqua; width: 30%; text-align: center;">
+      Responses:
+    </div>
+    <div id="timer" style="background-color: hotpink; width: 30%; text-align: center;"></div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Based on [this sample](https://bitbucket.org/chromiumembedded/cef-project/src/master/examples/message_router), this adds a way to signal in javascript (from the webpage) a couple of things:
- "ready" - page is ready for rendering, so enable cefsrc to go to a PAUSED/PLAYING state
- "eos" - page doesn't have any more content, so push an EOS event onto cefsrc

This is useful for pages that have non-trivial load times and may run out of content (webgl pages, pages with videos, etc).

There is a sample in the html/ directory that shows how to send the signals, e.g.:
```
window.gstSendMsg({
          request: "ready",
          onSuccess: function(response) { ... }
          },
          onFailure: function(error_code, error_message) { ... }
        });
      }
```
To test, run a webserver in the html directory, say:
```
python -m http.server 9000
```
Then just specify the flag in a run pointing at that page:
```
gst-launch-1.0 -e cefsrc url="http://localhost:9000/ready_test.html" listen-for-js-signals=true ! video/x-raw, width=1920, height=1080, framerate=60/1 ! cefdemux name=d d.video ! queue max-size-bytes=0 max-size-buffers=0 max-size-time=3000000000 ! videoconvert ! xvimagesink
```