### PR TITLE
Fix macOS and Linux build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,9 +84,13 @@ set(GSTCEF_SRCS
 )
 
 set(GSTCEFSUBPROCESS_SRCS
-  gstcefloader.cc
   gstcefsubprocess.cc
 )
+
+if (APPLE)
+list(APPEND GSTCEF_SRCS gstcefloader.cc)
+list(APPEND GSTCEFSUBPROCESS_SRCS gstcefloader.cc)
+endif()
 
 pkg_check_modules(GST REQUIRED gstreamer-1.0
                   gstreamer-video-1.0

--- a/gstcefsrc.cc
+++ b/gstcefsrc.cc
@@ -845,10 +845,10 @@ gst_cef_src_change_state(GstElement *src, GstStateChange transition)
       /* in the main thread as per Cocoa */
       if (pthread_main_np()) {
         g_mutex_unlock (&init_lock);
-        run_cef ((GstCefSrc*) src);
+        init_cef ((GstCefSrc*) src);
         g_mutex_lock (&init_lock);
       } else {
-        dispatch_async_f(dispatch_get_main_queue(), (GstCefSrc*)src, (dispatch_function_t)&run_cef);
+        dispatch_async_f(dispatch_get_main_queue(), (GstCefSrc*)src, (dispatch_function_t)&init_cef);
         while (cef_status == CEF_STATUS_INITIALIZING)
           g_cond_wait (&init_cond, &init_lock);
       }

--- a/gstcefsubprocess.cc
+++ b/gstcefsubprocess.cc
@@ -21,12 +21,11 @@
 #include <include/cef_app.h>
 #include <glib.h>
 
-#ifdef GST_CEF_USE_SANDBOX
+#if defined(__APPLE__)
 #include "gstcefloader.h"
-#endif
-
-#if !defined(__APPLE__) && defined(GST_CEF_USE_SANDBOX)
+#if defined(GST_CEF_USE_SANDBOX)
 #include "include/cef_sandbox_mac.h"
+#endif
 #endif
 
 
@@ -123,7 +122,7 @@ class RendererApp : public CefApp, public CefRenderProcessHandler {
 
 int main(int argc, char * argv[])
 {
-#if !defined(__APPLE__) && defined(GST_CEF_USE_SANDBOX)
+#if defined(__APPLE__) && defined(GST_CEF_USE_SANDBOX)
   // Initialize the macOS sandbox for this helper process.
   CefScopedSandboxContext sandbox_context;
   if (!sandbox_context.Initialize(argc, argv)) {
@@ -141,7 +140,7 @@ int main(int argc, char * argv[])
   CefMainArgs args(argc, argv);
 #endif
 
-#ifdef GST_CEF_USE_SANDBOX
+#if defined(__APPLE__) && defined(GST_CEF_USE_SANDBOX)
   // Try loading like an app bundle (1) or as
   // a sibling (2, at development time).
   if (!gst_initialize_cef(TRUE) && !gst_initialize_cef(FALSE)) {


### PR DESCRIPTION
Hi all,

This PR fixes two issues I was made aware of today:

- the macOS sandbox logic was being mistakenly built on Linux
- the event loop handler was renamed in 1931ae13940c5cb82ee3a07d5fed914ecf9b92c6, but that was not carried over to the state change handler for macOS