### PR TITLE
cefsrc: Clean up CEF object refs

### DIFF
--- a/gstcefsrc.h
+++ b/gstcefsrc.h
@@ -2,6 +2,7 @@
 #define __GST_CEF_SRC_H__
 
 #include "include/cef_browser_process_handler.h"
+#include "include/internal/cef_ptr.h"
 #include <gst/gst.h>
 #include <gst/base/gstpushsrc.h>
 #include <gst/video/video.h>
@@ -11,7 +12,7 @@
 #include <include/cef_life_span_handler.h>
 #include <include/cef_load_handler.h>
 #include <include/wrapper/cef_helpers.h>
-
+#include <include/wrapper/cef_message_router.h>
 
 G_BEGIN_DECLS
 
@@ -61,7 +62,7 @@ struct _GstCefSrc {
   gboolean listen_for_js_signals;
   gint chromium_debug_port;
   CefRefPtr<CefBrowser> browser;
-  CefRefPtr<CefApp> app;
+  CefRefPtr<CefClient> client;
 
   GCond state_cond;
   GMutex state_lock;


### PR DESCRIPTION
First raised here - https://github.com/centricular/gstcefsrc/pull/90#issuecomment-2393973894 - I am seeing some buffer corruption in the first `OnPaint` call when running multiple cefsrc elements.

It's not super deterministic, but looks like this:
![image](https://github.com/user-attachments/assets/d638e039-2f66-434e-9117-b89f269e55e4)

with the next frame being a successful paint:
![image](https://github.com/user-attachments/assets/eab2a669-b32d-41ad-af35-3f7cd09b4f4c)

I think the issue is possibly a CEF one (see https://magpcss.org/ceforum/viewtopic.php?f=6&t=18906), but this branch is me trying to improve the Cef object cleanup (to no avail - doesn't fix the issue, but pushing to get your thoughts).

I wonder if we should just drop the first frame / OnPaint call?

Commit msg:
We were never setting src->app, so I removed it from the struct... Also I added the BrowserClient to _GstCefSrc, so that I could try and ensure it is getting dereferenced.