### PR TITLE
macos: fix build against current CEF and clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,10 @@ project(gstcef)
 
 if (APPLE)
   enable_language(CXX OBJCXX)
-  set(CMAKE_OBJCXX_STANDARD 14)
+  # CEF 144 headers (base/cef_bind.h et al) use C++17 library features --
+  # std::void_t, conjunction, disjunction, bool_constant, in_place_t. CEF itself
+  # builds with -std=c++17 (cef_variables.cmake:290), so match it here.
+  set(CMAKE_OBJCXX_STANDARD 17)
   set(CMAKE_OBJCXX_STANDARD_REQUIRED ON)
 endif()
 
@@ -101,10 +104,16 @@ if(USE_SANDBOX)
   set(CMAKE_INSTALL_NAME_DIR "@rpath")
   add_compile_definitions("GST_CEF_USE_SANDBOX=1")
 endif()
-if (USE_SANDBOX AND (NOT DEFINED OS_LINUX))
-  ADD_LOGICAL_TARGET("libcef_lib" "${CEF_SANDBOX_LIB_DEBUG}" "${CEF_SANDBOX_LIB_RELEASE}")
-else()
-  ADD_LOGICAL_TARGET("libcef_lib" "${CEF_LIB_DEBUG}" "${CEF_LIB_RELEASE}")
+# On macOS the CEF distribution ships only Chromium Embedded Framework.framework --
+# there is no import library (cef_variables.cmake defines CEF_LIB_* / CEF_SANDBOX_LIB_*
+# for OS_LINUX and OS_WINDOWS only). The framework is dlopen'd at runtime instead, via
+# gstcefloader.cc / cef_load_library(). So no libcef_lib target on APPLE.
+if (NOT APPLE)
+  if (USE_SANDBOX AND (NOT DEFINED OS_LINUX))
+    ADD_LOGICAL_TARGET("libcef_lib" "${CEF_SANDBOX_LIB_DEBUG}" "${CEF_SANDBOX_LIB_RELEASE}")
+  else()
+    ADD_LOGICAL_TARGET("libcef_lib" "${CEF_LIB_DEBUG}" "${CEF_LIB_RELEASE}")
+  endif()
 endif()
 
 SET_CEF_TARGET_OUT_DIR()
@@ -121,7 +130,11 @@ endif()
 if (APPLE)
   target_sources("gstcef" PRIVATE gstcefnsapplication.mm)
 endif()
-target_link_libraries("gstcef" libcef_lib PkgConfig::PC_GLib)
+if (APPLE)
+  target_link_libraries("gstcef" PkgConfig::PC_GLib)
+else()
+  target_link_libraries("gstcef" libcef_lib PkgConfig::PC_GLib)
+endif()
 target_include_directories("gstcef" PUBLIC ${GST_INCLUDE_DIRS})
 set_target_properties("gstcef" PROPERTIES INSTALL_RPATH "$ORIGIN")
 set_target_properties("gstcef" PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
@@ -196,7 +209,8 @@ else()
       MACOSX_BUNDLE_GUI_IDENTIFIER "org.gstreamer.gstcefsubprocess${_plist_suffix}"
       )
 
-    target_link_libraries(${_helper_target} libcef_lib PkgConfig::PC_GLib)
+    # No libcef_lib on macOS (see note above) -- framework is loaded at runtime.
+    target_link_libraries(${_helper_target} PkgConfig::PC_GLib)
 
     # Add the Helper as a dependency of the main executable target.
     add_dependencies(gstcef "${_helper_target}")

--- a/gstcefsrc.cc
+++ b/gstcefsrc.cc
@@ -912,6 +912,18 @@ done:
   return NULL;
 }
 
+#ifdef __APPLE__
+/* dispatch_function_t is void (*)(void *), while init_cef is
+ * gpointer (*)(GstCefSrc *). Calling through a mismatched function pointer type
+ * is undefined behaviour, and newer clang diagnoses the cast via
+ * -Wcast-function-type-mismatch. Use a correctly typed trampoline instead. */
+static void
+init_cef_on_main_queue (void *src)
+{
+  init_cef ((GstCefSrc *) src);
+}
+#endif
+
 static GstStateChangeReturn
 gst_cef_src_change_state(GstElement *src, GstStateChange transition)
 {
@@ -938,7 +950,7 @@ gst_cef_src_change_state(GstElement *src, GstStateChange transition)
         init_cef ((GstCefSrc*) src);
         g_mutex_lock (&init_lock);
       } else {
-        dispatch_async_f(dispatch_get_main_queue(), (GstCefSrc*)src, (dispatch_function_t)&init_cef);
+        dispatch_async_f(dispatch_get_main_queue(), src, init_cef_on_main_queue);
         while (cef_status == CEF_STATUS_INITIALIZING)
           g_cond_wait (&init_cond, &init_lock);
       }

--- a/gstcefsrc.cc
+++ b/gstcefsrc.cc
@@ -345,27 +345,28 @@ class AudioHandler : public CefAudioHandler
     if (cef_pts_unix > now_unix) {
       GstClockTime diff = cef_pts_unix - now_unix;
       capture_gst = now_gst + diff;
-      GST_DEBUG_OBJECT (src, "diff %lu", diff);
+      GST_DEBUG_OBJECT (src, "diff %" G_GUINT64_FORMAT, diff);
     } else {
       GstClockTime diff = now_unix - cef_pts_unix;
       if (now_gst > diff)
         capture_gst = now_gst - diff;
       else
         capture_gst = 0;
-      GST_DEBUG_OBJECT (src, "diff -%lu", diff);
+      GST_DEBUG_OBJECT (src, "diff -%" G_GUINT64_FORMAT, diff);
     }
 
     GstClockTime gst_pts;
     if (capture_gst > base_time) {
       gst_pts = capture_gst - base_time;
     } else {
-      GST_WARNING_OBJECT (src, "audio pts (%lu) < base time (%lu)", capture_gst, base_time);
+      GST_WARNING_OBJECT (src, "audio pts (%" G_GUINT64_FORMAT ") < base time (%"
+          G_GUINT64_FORMAT ")", capture_gst, base_time);
       gst_pts = 0;
     }
     gst_object_unref (clock);
 
     GST_BUFFER_PTS (buf) = gst_pts;
-    GST_DEBUG_OBJECT (src, "audio pts %lu", gst_pts);
+    GST_DEBUG_OBJECT (src, "audio pts %" G_GUINT64_FORMAT, gst_pts);
 
     g_mutex_lock (&src->queue_lock);
 


### PR DESCRIPTION
## Summary

The macOS build is currently broken against current CEF and current clang. This fixes it; no behaviour changes on Linux or Windows.

Everything here is guarded by `if (NOT APPLE)` / `#ifdef __APPLE__`, or is a format-string correction that is a no-op on LP64 Linux.

## The problems

**1. `libcef_lib` does not exist on macOS — configure fails outright.**

`ADD_LOGICAL_TARGET("libcef_lib", ...)` and the two `target_link_libraries(... libcef_lib ...)` calls reachable on Apple are unconditional. But CEF's `cef_variables.cmake` defines `CEF_LIB_DEBUG`/`CEF_LIB_RELEASE` only under `OS_LINUX` (`libcef.so`) and `OS_WINDOWS` (`libcef.lib`), and defines `CEF_SANDBOX_LIB_*` under neither. The macOS distribution ships only `Chromium Embedded Framework.framework` — there is no import library at all.

That is by design, and this project already accounts for it: `gstcefloader.cc` is compiled on Apple precisely so the framework can be `dlopen`ed at runtime via `cef_load_library()`, and macOS `CEF_STANDARD_LIBS` contains only system frameworks. So macOS should never link `libcef_lib`.

Both branches expand to empty paths, and `cmake_policy(SET CMP0111 NEW)` at the top of `CMakeLists.txt` turns that into a hard error:

```
CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION or IMPORTED_IMPLIB not set for imported target
  "libcef_lib" configuration "Release".
```

(`-DUSE_SANDBOX=OFF` does not help — the `else` branch is equally undefined on macOS.)

**2. `CMAKE_OBJCXX_STANDARD` is 14, but CEF headers need C++17.**

`include/base/cef_bind.h` and friends use `std::void_t`, `std::conjunction`, `std::disjunction`, `std::bool_constant` and `std::in_place_t`. CEF itself compiles with `-std=c++17` (`cef_variables.cmake`), so this matches it.

**3. Undefined function-pointer cast.**

`init_cef` is `gpointer (*)(GstCefSrc *)`, cast to `dispatch_function_t` — `void (*)(void *)`. Calling through a mismatched function pointer type is UB, and clang now diagnoses it as `-Wcast-function-type-mismatch`, which `-Werror` makes fatal. Fixed with a correctly typed trampoline rather than by widening the cast or suppressing the warning.

**4. `GstClockTime` format strings.**

`GstClockTime` is `guint64`. On LP64 Linux that is `unsigned long`, so `%lu` happens to be correct; on macOS it is `unsigned long long` and `-Wformat` rejects it. `G_GUINT64_FORMAT` is correct everywhere.

## Testing

Built and run on macOS arm64 (Apple silicon), GStreamer 1.28.6, CEF `144.0.21+g4f5b28c+chromium-144.0.7559.248`, on top of `c89c2ce`:

- Configures and builds clean with upstream's `-Werror`, no suppressions.
- `cefsrc`, `cefdemux` and `cefbin` all register.
- Renders correctly: pages produce BGRA frames with correct content.
- **Per-pixel alpha is correct** — a page with `background: transparent` and a red `<div>` yields exactly `a=255` inside the div and `a=0` outside (`(0,0,0,0)`), which is what makes it usable as a broadcast overlay.

Also exercised in a real application (Eyevinn Strom) compositing a transparent CEF page as a downstream keyer over a program feed.

Note for anyone reproducing: on macOS CEF refuses to initialise unless the host process is inside an `.app` bundle — an unbundled `gst-launch-1.0` hangs silently at PAUSED. The README's bundle instructions are required, not optional.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
