### PR TITLE
cefsrc: Bound the frame and audio queues

### DIFF
--- a/gstcefsrc.cc
+++ b/gstcefsrc.cc
@@ -56,6 +56,13 @@ GST_DEBUG_CATEGORY_STATIC (cef_console_debug);
  * width * height * 4 bytes retained per paint — 8.3 MB at 1080p — until the
  * process is killed. Two lets a new frame land while one is in flight. */
 #define MAX_QUEUED_FRAMES 2
+
+/* Same reasoning for the audio packet list, which is drained by the same
+ * create() call. Packets are far smaller than frames, so this is set well
+ * above anything normal operation produces — the list is emptied on every
+ * video frame, so it sits at a handful of entries — and only trips when the
+ * consumer has stopped entirely. */
+#define MAX_QUEUED_AUDIO_BUFFERS 128
 #define DEFAULT_URL "https://www.google.com"
 #define DEFAULT_GPU FALSE
 #define DEFAULT_CHROMIUM_DEBUG_PORT -1
@@ -391,6 +398,15 @@ class AudioHandler : public CefAudioHandler
 
     if (!src->audio_buffers) {
       src->audio_buffers = gst_buffer_list_new();
+    }
+
+    /* As with the frame queue: nothing drains this while the pipeline is not
+     * PLAYING, so drop the oldest packets rather than grow without limit. */
+    guint n_audio = gst_buffer_list_length (src->audio_buffers);
+    if (n_audio >= MAX_QUEUED_AUDIO_BUFFERS) {
+      guint drop = n_audio - MAX_QUEUED_AUDIO_BUFFERS + 1;
+      GST_DEBUG_OBJECT (src, "audio queue full, dropping %u stale buffers", drop);
+      gst_buffer_list_remove (src->audio_buffers, 0, drop);
     }
 
     gst_buffer_list_add (src->audio_buffers, buf);

--- a/gstcefsrc.cc
+++ b/gstcefsrc.cc
@@ -45,6 +45,17 @@ GST_DEBUG_CATEGORY_STATIC (cef_console_debug);
 #define DEFAULT_HEIGHT 1080
 #define DEFAULT_FPS_N 30
 #define DEFAULT_FPS_D 1
+
+/* Upper bound on frames held between the browser thread and the streaming
+ * thread. CEF paints at the negotiated framerate (SetWindowlessFrameRate) and
+ * gst_cef_src_create() pops one frame per call, so in steady state the queue
+ * holds a single frame — which is the latency this element reports. The queue
+ * only grows when nothing is popping, and create() is gated behind
+ * gst_base_src_wait_playing(): a pipeline parked in PAUSED drains nothing at
+ * all while the browser keeps painting. Left unbounded that is
+ * width * height * 4 bytes retained per paint — 8.3 MB at 1080p — until the
+ * process is killed. Two lets a new frame land while one is in flight. */
+#define MAX_QUEUED_FRAMES 2
 #define DEFAULT_URL "https://www.google.com"
 #define DEFAULT_GPU FALSE
 #define DEFAULT_CHROMIUM_DEBUG_PORT -1
@@ -266,6 +277,13 @@ class RenderHandler : public CefRenderHandler
       GST_BUFFER_PTS (new_buffer) = gst_pts;
 
       g_mutex_lock (&src->queue_lock);
+      /* Drop the oldest frames rather than the one just painted: a consumer
+       * that has fallen behind wants current content, not a backlog. */
+      while (gst_queue_array_get_length (src->queue) >= MAX_QUEUED_FRAMES) {
+        GstBuffer *stale = (GstBuffer *) gst_queue_array_pop_head (src->queue);
+        GST_DEBUG_OBJECT (src, "queue full, dropping stale frame");
+        gst_buffer_unref (stale);
+      }
       gst_queue_array_push_tail (src->queue, new_buffer);
       GST_LOG_OBJECT (src, "frame buffer queue len: %u", gst_queue_array_get_length(src->queue));
       g_cond_signal (&src->queue_cond);


### PR DESCRIPTION
`RenderHandler::OnPaint` allocates a full frame and appends it to `src->queue` on every paint. Since #112 it discards frames in PAUSED, but in PLAYING it still queues unconditionally, and the only consumer is `gst_cef_src_create()` on the streaming task. If that task stops while the element stays in PLAYING, the queue grows by `width * height * 4` bytes per paint (8.3 MB at 1080p) until the process runs out of memory.

We hit this when downstream caps pinned a framerate that `cefsrc`'s `0/1` could not satisfy: `gst_base_src_loop` paused the task on `GST_FLOW_NOT_NEGOTIATED`, the pipeline stayed in PLAYING, and the browser kept painting. A leaky queue downstream does not prevent this, since `create()` is not being called and the queue forwards `NOT_NEGOTIATED` upstream anyway. On macOS CEF installs PartitionAlloc process-wide, so the failed allocation aborts inside `OnPaint` instead of returning NULL.

## Changes

- Cap the frame queue at 2 and drop the oldest frame. In steady state `create()` pops one frame per paint, so the cap only engages once draining has stopped.
- Cap `src->audio_buffers` at 128 and drop the oldest packets. It is drained by the same `create()` call and normally holds a handful.

The commits are independent. #105 is orthogonal: with it the queue stays at one frame and this cap never engages.

## Testing

macOS/arm64, CEF 144.0.21, GStreamer 1.28.6; this branch and master built side by side. The page animates a 1920×1080 canvas and plays a WebAudio tone. Memory is `phys_footprint`, sampled once a second.

**Task stopped in PLAYING.** `cefsrc ! video/x-raw,framerate=30/1 ! fakesink` fails with `NOT_NEGOTIATED` while the element stays in PLAYING.

| build | duration | max frame queue | max audio list | footprint |
|---|---|---|---|---|
| master | 15 s (stopped early) | 446 | 638 | 58 → 3638 MB |
| this branch | 60 s | 2 | 128 | flat, 93–98 MB |

**Normal playback.** `cefsrc ! cefdemux` with both pads into `fakesink` for 30 s: 928 paints, frame queue and audio list never above 1, nothing dropped. `cefsrc ! fakesink` likewise dropped nothing.

Not run on Linux or Windows. The repo has no automated tests, so there is no regression test.

<details><summary>Crash evidence</summary>

Two aborts ~3h apart with identical stacks: `OnPaint → gst_buffer_new_allocate → _sysmem_new_block → malloc → brk #0` in CEF. `x23 = 0x7E9097` (1920×1080×4); `x1 = 0xA00000`, the 10 MiB chunk PartitionAlloc could not obtain.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
